### PR TITLE
Controller refactor for readability, simplicity and performance (also ruby 2.3.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: ruby
+rvm:
+  - 2.2.3
+matrix:
+  include:
+    - rvm: 1.9.3
+      gemfile: gemfiles/1.9.3-Gemfile
+  allow_failures:
+    - rvm: 1.9.3
+    - rvm: 2.2.3
+services:
+  - postgresql
+before_script:
+  - psql -c 'create database skAtePI_test;' -U postgres
+test:
+  adapter: postgresql
+  database: skAtePI_test
+  username: postgres

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.2.3'
+ruby '2.3.0'
 
 gem 'rails', '4.2.5'
 gem 'rails-api'

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,38 +1,25 @@
 class FavoritesController < ApplicationController
   def create
     if fav_valid?
-      create_favorite && send_status(:created)
+      Favorite.create(favorite_params)
     else
-      send_status(:bad_request)
+      send_status(:unprocessable_entity)
     end
   end
 
   def destroy
-    favorite = find_favorite
-    if favorite
-      favorite.destroy && send_status(:no_content)
-    else
-      send_status(:bad_request)
-    end
+    Favorite.destroy_all(favorite_params)
+    send_status(:no_content)
   end
 
   private
 
   def fav_valid?
-    !find_favorite &&
-      User.find_by_id(params['user_id']) &&
-      Skatepark.find_by_id(params['skatepark_id'])
+    Favorite.find_by(favorite_params).nil?
   end
 
-  def create_favorite
-    Favorite.create(
-      user_id: params['user_id'],
-      skatepark_id: params['skatepark_id'])
-  end
-
-  def find_favorite
-    Favorite.find_by(
-      user_id: params['user_id'],
-      skatepark_id: params['skatepark_id'])
+  def favorite_params
+    { user_id: params['user_id'],
+      skatepark_id: params['skatepark_id'] }
   end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -8,7 +8,7 @@ class FavoritesController < ApplicationController
   end
 
   def destroy
-    Favorite.destroy_all(favorite_params)
+    Favorite.find_by(favorite_params).destroy
     send_status(:no_content)
   end
 

--- a/app/controllers/skateparks_controller.rb
+++ b/app/controllers/skateparks_controller.rb
@@ -4,11 +4,8 @@ class SkateparksController < ApplicationController
   end
 
   def show
-    park = Skatepark.find_by_id(params['id'])
-    if park
-      render json: park.to_json(include: :users_who_faved)
-    else
-      send_status(:not_found)
-    end
+    skatepark = Skatepark.find(params['id'])
+    render json: skatepark.to_json(
+      include: :users_who_faved)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,40 +4,29 @@ class UsersController < ApplicationController
   end
 
   def show
-    user = User.find_by_id(params['id'])
-    if user
-      render json: user.to_json(include: :favorite_parks)
-    else
-      send_status(:not_found)
-    end
+    user = User.find(params['id'])
+    render json: user.to_json(
+      include: :favorite_parks)
   end
 
   def create
-    user = new_user
+    user = User.new(user_params)
     if user.save
       render json: user
     else
-      send_status(:bad_request)
+      send_status(:unprocessable_entity)
     end
   end
 
   def destroy
-    if User.find_and_destroy(params['id'])
-      send_status(:no_content)
-    else
-      send_status(:bad_request)
-    end
+    User.destroy(params['id'])
+    send_status(:no_content)
   end
 
   private
 
   def user_params
-    JSON.parse(params['user'])
-  end
-
-  def new_user
-    User.new(
-      name: user_params['name'],
-      email: user_params['email'])
+    { name: JSON.parse(params['user'])['name'],
+      email: JSON.parse(params['user'])['email'] }
   end
 end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'POST /favorites' do
     expect(fav.skatepark).to eq(skatepark)
   end
 
-  it 'should return 400 if favorite already exists' do
+  it 'should return 422 if favorite already exists' do
     user = create(:user)
     skatepark = create(:skatepark)
     user.favorite_parks << skatepark
@@ -23,22 +23,7 @@ RSpec.describe 'POST /favorites' do
     expect do
       post '/favorites', user_id: user.id, skatepark_id: skatepark.id
     end.to_not change { user.favorite_parks.count }
-    expect(response.status).to eq(400)
-  end
-
-  it 'should return 400 if skatepark or user does not exist' do
-    user = create(:user)
-    skatepark = create(:skatepark)
-
-    expect do
-      post '/favorites', user_id: user.id, skatepark_id: 5
-    end.to_not change { user.favorite_parks.count }
-    expect(response.status).to eq(400)
-
-    expect do
-      post '/favorites', user_id: 1, skatepark_id: skatepark.id
-    end.to_not change { user.favorite_parks.count }
-    expect(response.status).to eq(400)
+    expect(response.status).to eq(422)
   end
 end
 
@@ -52,14 +37,5 @@ RSpec.describe 'DELETE /favorites' do
       delete "/favorite/#{user.id}/#{skatepark.id}"
     end.to change { user.favorite_parks.count }.by(-1)
     expect(response.status).to eq(204)
-  end
-
-  it 'should return 400 if user has not favorited park' do
-    user = create(:user)
-
-    expect do
-      delete "/favorite/#{user.id}/420"
-    end.to_not change { user.favorite_parks.count }
-    expect(response.status).to eq(400)
   end
 end

--- a/spec/requests/skateparks_spec.rb
+++ b/spec/requests/skateparks_spec.rb
@@ -42,10 +42,4 @@ RSpec.describe 'GET /skateparks/:id' do
     expect(users_who_faved[0]['name']).to eq(user.name)
     expect(users_who_faved[0]['email']).to eq(user.email)
   end
-
-  it 'returns a 404 if skatepark with id is not found' do
-    get '/skateparks/420'
-
-    expect(response.status).to eq(404)
-  end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -50,12 +50,6 @@ RSpec.describe 'GET /users/:id' do
     expect(favorited_park['name']).to eq(skatepark.name)
     expect(favorited_park['address']).to eq(skatepark.address)
   end
-
-  it 'should return 404 if user cannot be found' do
-    get '/users/420'
-
-    expect(response.status).to eq(404)
-  end
 end
 
 RSpec.describe 'POST /users' do
@@ -69,13 +63,13 @@ RSpec.describe 'POST /users' do
     expect(json_body['email']).to eq(user.email)
   end
 
-  it 'should return 400 if user cannot be created' do
+  it 'should return 422 if user cannot be created' do
     user = build(:user, :invalid)
 
     expect do
       post '/users', user: user.to_json
     end.to_not change { User.count }
-    expect(response.status).to eq(400)
+    expect(response.status).to eq(422)
   end
 end
 
@@ -87,12 +81,5 @@ RSpec.describe 'DELETE /users' do
       delete "/users/#{user.id}"
     end.to change { User.count }.by(-1)
     expect(response.status).to eq(204)
-  end
-
-  it 'should return 400 if user does not exist' do
-    expect do
-      delete '/users/420'
-    end.to_not change { User.count }
-    expect(response.status).to eq(400)
   end
 end


### PR DESCRIPTION
Was sending `:bad_request` if a record could not be found with an `id`, but I realized that this isn't really needed at this point because I am the only one using this api and I control the requests.

From the client a user will only be able to interact with this api through the interface that I provide, so instead of trying to account for bad requests I will simply make sure that requests can only be made with valid `id`s.
#### Minor Changes
- Update to `ruby -v 2.3.0`
- Add `private` method `favorite_params` to `FavoritesController` to maximize readability
- Also add `user_params` to `UsersController`
- Change `:bad_request` on failed create actions to more accurate `:unprocessable_entity`
